### PR TITLE
Timeline events shift position when updated

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -4996,8 +4996,8 @@ links.Timeline.prototype.filterItems = function () {
                 if (rendered) {
                     queue.hide.push(item); // item is rendered but no longer visible
                 }
-                if (visible) {
-                    queue.show.push(item); // item is visible but not yet rendered
+                if (visible && (queue.show.indexOf(item) == -1)) {
+                    queue.show.push(item); // item is visible but neither rendered nor queued up to be rendered
                 }
             }
         });


### PR DESCRIPTION
Running `changeItem` to update a timeline event's contents causes it to shift its vertical position when the `stackEvents` option is enabled.

**Steps to reproduce:**
- Open `js/src/timeline/examples/example09_editable.html` in the latest version of the `chap-links-library` repository.
- Select an event in the timeline.
- Click the `Change` button above the timeline.

**Result:** the selected event moves upward.

**Expected result:** the event stays where it is.

**Cause:** `changeItem` does not actually change the timeline event, but creates a new event to replace the old one. Both `changeItem` and `filterItems` push the new event onto the timeline's `show` render queue. The duplicate event causes the proper vertical position of the replacement event to be miscalculated.

I have forked the repo and implemented a fix, and will be submitting a pull request very shortly.
