### PR TITLE
Timeline: Add an optional parameter to deleteItem() to prevent redrawing

### DIFF
--- a/js/src/timeline/doc/index.html
+++ b/js/src/timeline/doc/index.html
@@ -799,10 +799,11 @@ var options = {
 </tr>
 
 <tr>
-    <td>deleteItem(index)</td>
+    <td>deleteItem(index, preventRender)</td>
     <td>none</td>
     <td>Delete an existing item.
         <code>index</code> (Number) is the index of the item.
+        <code>preventRender</code> (Boolean) is optional parameter to prevent re-render timeline immediately after delete (for multiple deletions). Default is false.
     </td>
 </tr>
 

--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -3294,8 +3294,9 @@ links.Timeline.prototype.confirmDeleteItem = function(index) {
 /**
  * Delete an item
  * @param {int} index   Index of the item to be deleted
+ * @param {boolean} [preventRender=false]   Do not re-render timeline if true (optimization for multiple delete)
  */
-links.Timeline.prototype.deleteItem = function(index) {
+links.Timeline.prototype.deleteItem = function(index, preventRender) {
     if (index >= this.items.length) {
         throw "Cannot delete row, index out of range";
     }
@@ -3320,7 +3321,9 @@ links.Timeline.prototype.deleteItem = function(index) {
         }
     }
 
-    this.render();
+    if (!preventRender) {
+        this.render();
+    }
 };
 
 


### PR DESCRIPTION
I've faced a performance problem during multiple items deletion. I can delete them only item-by-item, and timeline is re-rendering after each deletion.

As a solution I've added optional parameter to `deleteItem()` function to prevent redrawing each time.
