### PR TITLE
Timeline: Userdata is added to timeline item

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -3407,6 +3407,7 @@ links.Timeline.Item = function (data, options) {
         this.className = data.className;
         this.editable = data.editable;
         this.group = data.group;
+        this.userdata = data.userdata;
 
         if (this.start) {
             if (this.end) {
@@ -4284,6 +4285,9 @@ links.Timeline.prototype.getItem = function (index) {
     if (item.group) {
         properties.group = this.getGroupName(item.group);
     }
+    if (item.userdata) {
+        properties.userdata = item.userdata;
+    }
 
     return properties;
 };
@@ -4348,6 +4352,7 @@ links.Timeline.prototype.createItem = function(itemData) {
         content: itemData.content,
         className: itemData.className,
         editable: itemData.editable,
+        userdata: itemData.userdata,
         group: this.getGroup(itemData.group)
     };
     // TODO: optimize this, when creating an item, all data is copied twice...


### PR DESCRIPTION
I've tried to add user data in timeline's items, as we discussed in #39.

New option `userdata` in item's description, which is just stored inside item and can be accessed using `getItem()` function.

What do you think about this solution? If it is appropriate, I can update documentation/examples.
