### PR TITLE
Timeline Items lose custom css classes when moved up or down timeline rows

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -4398,7 +4398,8 @@ links.Timeline.prototype.changeItem = function (index, itemData) {
         'start':   itemData.hasOwnProperty('start') ?   itemData.start :   oldItem.start,
         'end':     itemData.hasOwnProperty('end') ?     itemData.end :     oldItem.end,
         'content': itemData.hasOwnProperty('content') ? itemData.content : oldItem.content,
-        'group':   itemData.hasOwnProperty('group') ?   itemData.group :   this.getGroupName(oldItem.group)
+        'group':   itemData.hasOwnProperty('group') ?   itemData.group :   this.getGroupName(oldItem.group),
+		'className': itemData.hasOwnProperty('className') ? itemData.className : oldItem.className
     });
     this.items[index] = newItem;
 


### PR DESCRIPTION
A small problem with the 'changeItem' function, that was losing the 'className' property of timeline event items when re-creating them on different group rows.

This fix ensures custom css classes are preserved.
