### PR TITLE
Allow extension of links.Timeline using inheritation

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -4813,7 +4813,7 @@ links.Timeline.prototype.stackMoveOneStep = function(currentItems, finalItems) {
     var arrived = true;
 
     // apply new positions animated
-    for (i = 0, iMax = currentItems.length; i < iMax; i++) {
+    for (i = 0, iMax = finalItems.length; i < iMax; i++) {
         var finalItem = finalItems[i],
             item = finalItem.item;
 


### PR DESCRIPTION
Currently the constructor of the links.Timeline class requires a DOM element as container, and will raise a runtime-error, when no suitable object is handed in.

To be able to inherit from the links.Timeline class, one needs to call its constructor once only for this purpose, and without container of course. Therefore the constructor should return without container element immediately, so that no harm is done, but inheritation chain is build up.

Inheritation can then be realized using something like this:

```
MyCustomTimelineClass.prototype = new links.Timeline(null);
```

Since the Timeline class is so nicely distributed in small methods, nearly any thing can then be customized.

Another small fix was done in the stackMoveToFinal method, that now iterates over the finalItems-Array, as most other methods do, so that the finalItems-Array can be a subset of the currentItems-Array.
