### PR TITLE
Added "editable" properties to the return object in the getItem() method

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -4246,7 +4246,8 @@ links.Timeline.ItemDot.prototype.getRight = function (timeline) {
  *                              {Date} start (required),
  *                              {Date} end (optional),
  *                              {String} content (required),
- *                              {String} group (optional)
+ *                              {String} group (optional),
+ *                              {boolean} editable (optional)
  */
 links.Timeline.prototype.getItem = function (index) {
     if (index >= this.items.length) {
@@ -4263,6 +4264,9 @@ links.Timeline.prototype.getItem = function (index) {
     properties.content = item.content;
     if (item.group) {
         properties.group = this.getGroupName(item.group);
+    }
+    if (item.hasOwnProperty('editable') && (typeof item.editable != 'undefined')) {
+        properties.editable = item.editable;
     }
 
     return properties;


### PR DESCRIPTION
I have extended the return object of the getItem() method to "editable" property. It was missing, so that there was no chance to check if the item is editable or not and don't allow CRUD operations on such item. My changes:

``` javascript
    links.Timeline.prototype.getItem = function (index) {
        ...
        if (item.hasOwnProperty('editable') && (typeof item.editable != 'undefined')) {
            properties.editable = item.editable;
        }

        return properties;
    };
```

It would be nice if you can accept it. Thanks!
