### PR TITLE
Completed Timeline i18n (localized text)

### DIFF
--- a/js/src/timeline/tests/test_timeline_i18n.html
+++ b/js/src/timeline/tests/test_timeline_i18n.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Timeline i18n demo</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <style>
+        body {
+            font: 10pt verdana;
+        }
+    </style>
+
+    <script type="text/javascript" src="http://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="../timeline-locales.js"></script>
+    <script type="text/javascript" src="../timeline.js"></script>
+    <link rel="stylesheet" type="text/css" href="../timeline.css">
+
+    <script type="text/javascript">
+        google.load("visualization", "1");
+
+        // Set callback to run when API is loaded
+        google.setOnLoadCallback(drawVisualization);
+
+        var timeline;
+        var data;
+
+        function getSelectedRow() {
+            var row = undefined
+            var sel = timeline.getSelection();
+            if (sel.length) {
+                if (sel[0].row != undefined) {
+                    var row = sel[0].row;
+                }
+            }
+            return row;
+        }
+
+        // Called when the Visualization API is loaded.
+        function drawVisualization() {
+            // Create and populate a data table.
+            data = new google.visualization.DataTable();
+            data.addColumn('datetime', 'start');
+            data.addColumn('datetime', 'end');
+            data.addColumn('string', 'content');
+
+            data.addRows([
+                [new Date(2011, 01, 23), , '<div>Conversation</div><img src="../examples/img/comments-icon.png" style="width:32px; height:32px;">'],
+                [new Date(2011, 01, 23, 23, 00, 00), , '<div>Mail from boss</div><img src="../examples/img/mail-icon.png" style="width:32px; height:32px;">'],
+                [new Date(2011, 01, 24, 16, 00, 00), , '<span onclick="alert(\'test\')">Click here!</span>'],
+                [new Date(2011, 01, 26), new Date(2011, 02, 02), 'Traject A'],
+                [new Date(2011, 01, 27), , '<div>Memo</div><img src="../examples/img/notes-edit-icon.png" style="width:48px; height:48px;">'],
+                [new Date(2011, 01, 28), new Date(2011, 02, 03), 'Traject B'],
+                [new Date(2011, 02, 04, 12, 00, 00), , '<div>Report</div><img src="../examples/img/attachment-icon.png" style="width:32px; height:32px;">']
+            ]);
+
+            // specify options
+            var options = {
+                width: "100%",
+                height: "200px",
+                editable: true,   // enable dragging and editing events
+                enableKeys: true,
+                axisOnTop: false,
+                showNavigation: true,
+                showButtonNew: true,
+                animate: true,
+                animateZoom: true,
+                layout: "box"
+            };
+
+            timeline = new links.Timeline(document.getElementById('mytimeline1'));
+            options.locale = "de";
+            timeline.draw(data, options);
+
+            timeline = new links.Timeline(document.getElementById('mytimeline2'));
+            options.locale = "es";
+            timeline.draw(data, options);
+            
+            timeline = new links.Timeline(document.getElementById('mytimeline3'));
+            options.locale = "ru";
+            timeline.draw(data, options);            
+        }
+    </script>
+
+</head>
+
+<body>
+<p><strong>This page demonstrates the timeline localization (i18n text).</strong></p>
+
+<p><strong>German Timeline</strong></p>
+<div id="mytimeline1"></div>
+
+<p><strong>Spanish Timeline</strong></p>
+<div id="mytimeline2"></div>
+
+<p><strong>Russian Timeline</strong></p>
+<div id="mytimeline3"></div>
+
+<!-- Information about where the used icons come from -->
+<p style="color:gray; font-size:10px; font-style:italic;">
+    Icons by <a href="http://dryicons.com" target="_blank" title="Aesthetica 2 Icons by DryIcons" style="color:gray;">DryIcons</a>
+    and <a href="http://www.tpdkdesign.net" target="_blank" title="Refresh Cl Icons by TpdkDesign.net" style="color:gray;">TpdkDesign.net</a>
+</p>
+</body>
+</html>

--- a/js/src/timeline/timeline-locales.js
+++ b/js/src/timeline/timeline-locales.js
@@ -1,0 +1,97 @@
+if (typeof links === 'undefined') {
+    links = {};
+    links.locales = {};
+} else if (typeof links.locales === 'undefined') {
+    links.locales = {};
+}
+
+// English ===================================================
+links.locales['en_US'] = {
+    'MONTHS': new Array("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"),
+    'MONTHS_SHORT': new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
+    'DAYS': new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"),
+    'DAYS_SHORT': new Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+    'ZOOM_IN': "Zoom in",
+    'ZOOM_OUT': "Zoom out",
+    'MOVE_LEFT': "Move left",
+    'MOVE_RIGHT': "Move right",
+    'NEW': "New",
+    'CREATE_NEW_EVENT': "Create new event"
+};
+
+links.locales['en_UK'] = links.locales['en_US'];
+
+// Catalan ===================================================
+links.locales['ca'] = {
+    'MONTHS': new Array("Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Setembre", "Octubre", "Novembre", "Desembre"),
+    'MONTHS_SHORT': new Array("Gen", "Feb", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Oct", "Nov", "Des"),
+    'DAYS': new Array("Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"),
+    'DAYS_SHORT': new Array("Dm.", "Dl.", "Dm.", "Dc.", "Dj.", "Dv.", "Ds."),
+    'ZOOM_IN': "Augmentar zoom",
+    'ZOOM_OUT': "Disminuir zoom",
+    'MOVE_LEFT': "Moure esquerra",
+    'MOVE_RIGHT': "Moure dreta",
+    'NEW': "Nou",
+    'CREATE_NEW_EVENT': "Crear nou event"
+};
+
+// German ===================================================
+links.locales['de'] = {
+    'MONTHS': new Array("Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"),
+    'MONTHS_SHORT': new Array("Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"),
+    'DAYS': new Array("Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"),
+    'DAYS_SHORT': new Array("Son", "Mon", "Die", "Mit", "Don", "Fre", "Sam"),
+    'ZOOM_IN': "Vergrößern",
+    'ZOOM_OUT': "Verkleinern",
+    'MOVE_LEFT': "Nach links verschieben",
+    'MOVE_RIGHT': "Nach rechts verschieben",
+    'NEW': "Neu",
+    'CREATE_NEW_EVENT': "Neues Ereignis erzeugen"
+};
+
+links.locales['de_DE'] = links.locales['de'];
+links.locales['de_CH'] = links.locales['de'];
+
+// Danish ===================================================
+links.locales['da_DK'] = {
+    'MONTHS': new Array("januar", "februar", "marts", "april", "maj", "juni", "juli", "august", "september", "oktober", "november", "december"),
+    'MONTHS_SHORT': new Array("jan", "feb", "mar", "apr", "maj", "jun", "jul", "aug", "sep", "okt", "nov", "dec"),
+    'DAYS': new Array("søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"),
+    'DAYS_SHORT': new Array("søn", "man", "tir", "ons", "tor", "fre", "lør"),
+    'ZOOM_IN': "Zoom in",
+    'ZOOM_OUT': "Zoom out",
+    'MOVE_LEFT': "Move left",
+    'MOVE_RIGHT': "Move right",
+    'NEW': "New",
+    'CREATE_NEW_EVENT': "Create new event"
+};
+
+// Russian ===================================================
+links.locales['ru'] = {
+    'MONTHS': new Array("Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"),
+    'MONTHS_SHORT': new Array("Янв", "Фев", "Мар", "Апр", "Май", "Июн", "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек"),
+    'DAYS': new Array("Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"),
+    'DAYS_SHORT': new Array("Вос", "Пон", "Втo", "Срe", "Чет", "Пят", "Суб"),
+    'ZOOM_IN': "Увeличить",
+    'ZOOM_OUT': "Умeньшить",
+    'MOVE_LEFT': "Сдвинуть налeво",
+    'MOVE_RIGHT': "Сдвинуть направо",
+    'NEW': "Новый",
+    'CREATE_NEW_EVENT': "Создать новоe событиe"
+};
+
+// Spanish ===================================================
+links.locales['es'] = {
+    'MONTHS': new Array("Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"),
+    'MONTHS_SHORT': new Array("Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"),
+    'DAYS': new Array("Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"),
+    'DAYS_SHORT': new Array("Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"),
+    'ZOOM_IN': "Aumentar zoom",
+    'ZOOM_OUT': "Disminuir zoom",
+    'MOVE_LEFT': "Mover izquierda",
+    'MOVE_RIGHT': "Mover derecha",
+    'NEW': "Nuevo",
+    'CREATE_NEW_EVENT': "Crear nuevo evento"
+};
+
+links.locales['es_ES'] = links.locales['es'];

--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -207,21 +207,18 @@ links.Timeline = function(container) {
         'style': 'box',
         'customStackOrder': false, //a function(a,b) for determining stackorder amongst a group of items. Essentially a comparator, -ve value for "a before b" and vice versa
         
-        'lang': 'en_US',
-        'i18n': {
-           'en_US' : {
-               'MONTHS_SHORT' : new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
-               'MONTHS' : new Array("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"),
-               'DAYS' : new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"),
-               'DAYS_SHORT' : new Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
-           },
-           'da_DK' : {
-               'MONTHS_SHORT' : new Array("jan", "feb", "mar", "apr", "maj", "jun", "jul", "aug", "sep", "okt", "nov", "dec"),
-               'MONTHS' : new Array("januar", "februar", "marts", "april", "maj", "juni", "juli", "august", "september", "oktober", "november", "december"),
-               'DAYS' : new Array("søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"),
-               'DAYS_SHORT' : new Array("søn", "man", "tir", "ons", "tor", "fre", "lør")
-           }
-        }
+        // i18n: Timeline only has built-in English text per default. Include timeline-locales.js to support more localized text.
+        'locale': 'en',
+        'MONTHS': new Array("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"),
+        'MONTHS_SHORT': new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
+        'DAYS': new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"),
+        'DAYS_SHORT': new Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"),
+        'ZOOM_IN': "Zoom in",
+        'ZOOM_OUT': "Zoom out",
+        'MOVE_LEFT': "Move left",
+        'MOVE_RIGHT': "Move right",
+        'NEW': "New",
+        'CREATE_NEW_EVENT': "Create new event"
     };
 
     this.clientTimeOffset = 0;    // difference between client time and the time
@@ -304,6 +301,18 @@ links.Timeline.prototype.setOptions = function(options) {
         for (var i in options) {
             if (options.hasOwnProperty(i)) {
                 this.options[i] = options[i];
+            }
+        }
+        
+        // prepare i18n dependent on set locale
+        if (typeof links.locales !== 'undefined' && this.options.locale !== 'en') {
+            var localeOpts = links.locales[this.options.locale];
+            if(localeOpts) {
+                for (var l in localeOpts) {
+                    if (localeOpts.hasOwnProperty(l)) {
+                        this.options[l] = localeOpts[l];
+                    }
+                }
             }
         }
 
@@ -2164,7 +2173,7 @@ links.Timeline.prototype.repaintNavigation = function () {
             navBar.addButton = document.createElement("DIV");
             navBar.addButton.className = "timeline-navigation-new";
 
-            navBar.addButton.title = "Create new event";
+            navBar.addButton.title = options.CREATE_NEW_EVENT;
             var onAdd = function(event) {
                 links.Timeline.preventDefault(event);
                 links.Timeline.stopPropagation(event);
@@ -2179,7 +2188,7 @@ links.Timeline.prototype.repaintNavigation = function () {
                     timeline.step.snap(xend);
                 }
 
-                var content = "New";
+                var content = options.NEW;
                 var group = timeline.groups.length ? timeline.groups[0].content : undefined;
                 var preventRender = true;
                 timeline.addItem({
@@ -2223,7 +2232,7 @@ links.Timeline.prototype.repaintNavigation = function () {
                 // create a zoom in button
                 navBar.zoomInButton = document.createElement("DIV");
                 navBar.zoomInButton.className = "timeline-navigation-zoom-in";
-                navBar.zoomInButton.title = "Zoom in";
+                navBar.zoomInButton.title = this.options.ZOOM_IN;
                 var onZoomIn = function(event) {
                     links.Timeline.preventDefault(event);
                     links.Timeline.stopPropagation(event);
@@ -2237,7 +2246,7 @@ links.Timeline.prototype.repaintNavigation = function () {
                 // create a zoom out button
                 navBar.zoomOutButton = document.createElement("DIV");
                 navBar.zoomOutButton.className = "timeline-navigation-zoom-out";
-                navBar.zoomOutButton.title = "Zoom out";
+                navBar.zoomOutButton.title = this.options.ZOOM_OUT;
                 var onZoomOut = function(event) {
                     links.Timeline.preventDefault(event);
                     links.Timeline.stopPropagation(event);
@@ -2253,7 +2262,7 @@ links.Timeline.prototype.repaintNavigation = function () {
                 // create a move left button
                 navBar.moveLeftButton = document.createElement("DIV");
                 navBar.moveLeftButton.className = "timeline-navigation-move-left";
-                navBar.moveLeftButton.title = "Move left";
+                navBar.moveLeftButton.title = this.options.MOVE_LEFT;
                 var onMoveLeft = function(event) {
                     links.Timeline.preventDefault(event);
                     links.Timeline.stopPropagation(event);
@@ -2267,7 +2276,7 @@ links.Timeline.prototype.repaintNavigation = function () {
                 // create a move right button
                 navBar.moveRightButton = document.createElement("DIV");
                 navBar.moveRightButton.className = "timeline-navigation-move-right";
-                navBar.moveRightButton.title = "Move right";
+                navBar.moveRightButton.title = this.options.MOVE_RIGHT;
                 var onMoveRight = function(event) {
                     links.Timeline.preventDefault(event);
                     links.Timeline.stopPropagation(event);
@@ -2619,7 +2628,7 @@ links.Timeline.prototype.onMouseDown = function(event) {
             this.step.snap(xstart);
         }
         var xend = new Date(xstart.valueOf());
-        var content = "New";
+        var content = options.NEW;
         var group = this.getGroupFromHeight(y);
         this.addItem({
             'start': xstart,
@@ -2986,7 +2995,7 @@ links.Timeline.prototype.onDblClick = function (event) {
                 this.step.snap(xend);
             }
 
-            var content = "New";
+            var content = options.NEW;
             var group = this.getGroupFromHeight(y);   // (group may be undefined)
             var preventRender = true;
             this.addItem({
@@ -5848,6 +5857,7 @@ links.Timeline.StepDate.prototype.isMajor = function() {
  * Returns formatted text for the minor axislabel, depending on the current
  * date and the scale. For example when scale is MINUTE, the current time is
  * formatted as "hh:mm".
+ * @param {Object} options
  * @param {Date} [date] custom date. if not provided, current date is taken
  */
 links.Timeline.StepDate.prototype.getLabelMinor = function(options, date) {
@@ -5862,9 +5872,9 @@ links.Timeline.StepDate.prototype.getLabelMinor = function(options, date) {
             return this.addZeros(date.getHours(), 2) + ":" + this.addZeros(date.getMinutes(), 2);
         case links.Timeline.StepDate.SCALE.HOUR:
             return this.addZeros(date.getHours(), 2) + ":" + this.addZeros(date.getMinutes(), 2);
-        case links.Timeline.StepDate.SCALE.WEEKDAY:      return options.i18n[options.lang].DAYS_SHORT[date.getDay()] + ' ' + date.getDate();
+        case links.Timeline.StepDate.SCALE.WEEKDAY:      return options.DAYS_SHORT[date.getDay()] + ' ' + date.getDate();
         case links.Timeline.StepDate.SCALE.DAY:          return String(date.getDate());
-        case links.Timeline.StepDate.SCALE.MONTH:        return options.i18n[options.lang].MONTHS_SHORT[date.getMonth()];   // month is zero based
+        case links.Timeline.StepDate.SCALE.MONTH:        return options.MONTHS_SHORT[date.getMonth()];   // month is zero based
         case links.Timeline.StepDate.SCALE.YEAR:         return String(date.getFullYear());
         default:                                         return "";
     }
@@ -5875,6 +5885,7 @@ links.Timeline.StepDate.prototype.getLabelMinor = function(options, date) {
  * Returns formatted text for the major axislabel, depending on the current
  * date and the scale. For example when scale is MINUTE, the major scale is
  * hours, and the hour will be formatted as "hh".
+ * @param {Object} options
  * @param {Date} [date] custom date. if not provided, current date is taken
  */
 links.Timeline.StepDate.prototype.getLabelMajor = function(options, date) {
@@ -5889,22 +5900,22 @@ links.Timeline.StepDate.prototype.getLabelMajor = function(options, date) {
                 this.addZeros(date.getSeconds(), 2);
         case links.Timeline.StepDate.SCALE.SECOND:
             return  date.getDate() + " " +
-                options.i18n[options.lang].MONTHS[date.getMonth()] + " " +
+                options.MONTHS[date.getMonth()] + " " +
                 this.addZeros(date.getHours(), 2) + ":" +
                 this.addZeros(date.getMinutes(), 2);
         case links.Timeline.StepDate.SCALE.MINUTE:
-            return  options.i18n[options.lang].DAYS[date.getDay()] + " " +
+            return  options.DAYS[date.getDay()] + " " +
                 date.getDate() + " " +
-                options.i18n[options.lang].MONTHS[date.getMonth()] + " " +
+                options.MONTHS[date.getMonth()] + " " +
                 date.getFullYear();
         case links.Timeline.StepDate.SCALE.HOUR:
-            return  options.i18n[options.lang].DAYS[date.getDay()] + " " +
+            return  options.DAYS[date.getDay()] + " " +
                 date.getDate() + " " +
-                options.i18n[options.lang].MONTHS[date.getMonth()] + " " +
+                options.MONTHS[date.getMonth()] + " " +
                 date.getFullYear();
         case links.Timeline.StepDate.SCALE.WEEKDAY:
         case links.Timeline.StepDate.SCALE.DAY:
-            return  options.i18n[options.lang].MONTHS[date.getMonth()] + " " +
+            return  options.MONTHS[date.getMonth()] + " " +
                 date.getFullYear();
         case links.Timeline.StepDate.SCALE.MONTH:
             return String(date.getFullYear());


### PR DESCRIPTION
Hi,

I have finished the Timeline internationalization completely as promised. All text incl. actions are i18n aware now. I have separated translations to an extra file **timeline-locales.js** This file should be included on page before **timeline.js** if i18n text are needed. This allow to keeps the core file small and don't blow up with a lot of i18n text. At the moment there are translations in English, Catalan, German, Danish (partial), Russian, Spanish. Everybody how needs more translations should add them to this file!

I have also created a demo HTML file. Please take a look into **test_timeline_i18n.html** in test folder. It works like a charm.

Thanks in advance!
