### PR TITLE
Feature request: option to disable event unselection

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -188,7 +188,7 @@ links.Timeline = function(container) {
         'moveable': true,
         'zoomable': true,
         'selectable': true,
-        'unselectable': false,
+        'unselectable': true,
         'editable': false,
         'snapEvents': true,
         'groupChangeable': true,
@@ -2942,7 +2942,7 @@ links.Timeline.prototype.onMouseUp = function (event) {
                     }
                 }
                 else {
-                    if (!options.unselectable) {
+                    if (options.unselectable) {
                         this.unselectItem();
                         this.trigger('select');
                     }


### PR DESCRIPTION
This new option prevents the user to unselect events. The event 'select' not fires when 'unselectable' is set to true. Default is false.
