### PR TITLE
Tolerate undefined start & end in getDataRange()

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -718,18 +718,12 @@ links.Timeline.prototype.getDataRange = function (withMargin) {
                 start = item.start != undefined ? item.start.valueOf() : undefined,
                 end   = item.end != undefined   ? item.end.valueOf() : start;
 
-            if (min != undefined && start != undefined) {
-                min = Math.min(min.valueOf(), start.valueOf());
-            }
-            else {
-                min = start;
+            if (start != undefined) {
+                min = (min != undefined) ? Math.min(min.valueOf(), start.valueOf()) : start;
             }
 
-            if (max != undefined && end != undefined) {
-                max = Math.max(max, end);
-            }
-            else {
-                max = end;
+            if (end != undefined) {
+                max = (max != undefined) ? Math.max(max.valueOf(), end.valueOf()) : end;
             }
         }
     }


### PR DESCRIPTION
'start' isn't supposed to be an optional entry in an item, but in a project I accidentally generated a few items that had neither start nor end, amongst many items that _did_. The timeline chart looked fine, but the functionality of setVisibleChartRangeAuto() was broken, so the chart was zoomed to the default of 'now', rather than to show all the properly defined elements.

This fix makes the function more tolerant of bad data, and the zoom level is now back to the expected behaviour.
