### PR TITLE
Center zoom buttons

### DIFF
--- a/js/src/graph/graph.css
+++ b/js/src/graph/graph.css
@@ -44,6 +44,7 @@ div.graph-axis-button {
     margin-right: 5px;
     margin-bottom: 5px;
     cursor: pointer;
+    line-height: 13px;
 }
 div.graph-axis-button:hover {
     background-color: gray;


### PR DESCRIPTION
The `+` and `-` buttons are now centered (vertically) using the CSS `line-height` property.
