### PR TITLE
Implement shift-scroll (horizontal TL scroll) and shift-ctrl-scroll

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -3109,16 +3109,7 @@ links.Timeline.prototype.onMouseWheel = function(event) {
             timeline.trigger("rangechanged");
         };
 
-        var verticalScroll = function () {
-            // Vertically scroll the timeline
-            window.scrollBy(0, delta * -50);
-            timeline.trigger("rangechange");
-            timeline.trigger("rangechanged");
-        };
-
-        if (event.shiftKey && event.ctrlKey)
-            verticalScroll();
-        else if (event.shiftKey)
+        if (event.shiftKey)
             scroll();
         else
             zoom();


### PR DESCRIPTION
To ease navigation in the timeline, the (standard) Shift-scroll should do a horizontal scrolling. I also added a (non-standard) shift-ctrl-scroll for vertical scrolling.
