### PR TITLE
typo in doc: option is called groupChangeable and not groupsChangeable

### DIFF
--- a/js/src/timeline/doc/index.html
+++ b/js/src/timeline/doc/index.html
@@ -55,7 +55,7 @@
 </p>
 
 <p>
-    When the timeline is defined as editable (and groupsChangeable and timeChangeable are set accordingly), events can be moved to another time
+    When the timeline is defined as editable (and groupChangeable and timeChangeable are set accordingly), events can be moved to another time
     by dragging them. By double clicking, the contents of an event can be changed.
     An event can be deleted by clicking the delete button on the upper right.
     A new event can be added in different
@@ -508,7 +508,7 @@ var options = {
 </tr>
 
 <tr>
-    <td>groupsChangeable</td>
+    <td>groupChangeable</td>
     <td>boolean</td>
     <td>false</td>
     <td>If true, items can be moved from one group to another.
@@ -750,7 +750,7 @@ var options = {
     <td>boolean</td>
     <td>true</td>
     <td>If false, items can not be moved or dragged horizontally (neither start time nor end time is changable).
-        This is useful when items should be editable but can only be changed regarding group or content (typical use case: scheduling events). See also the option <code>groupsChangeable</code>.</td>
+        This is useful when items should be editable but can only be changed regarding group or content (typical use case: scheduling events). See also the option <code>groupChangeable</code>.</td>
 </tr>
 
 


### PR DESCRIPTION
Fixed a typo in the docs. Option is called groupChangeable and not groupsChangeable (as of your master). groupsChangeable implies the wrong thing anyway, but thats just my two cents ;-)
