### PR TITLE
allow to change the event in the triggered event handlers

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -2950,6 +2950,9 @@ links.Timeline.prototype.onMouseUp = function (event) {
             // Note that the change can be canceled from within an event listener if
             // this listener calls the method cancelChange().
             this.trigger(params.addItem ? 'add' : 'changed');
+            
+            //retrieve item data again to include changes made to it in the triggered event handlers
+            item = this.items[params.itemIndex];
 
             if (params.addItem) {
                 if (this.applyAdd) {


### PR DESCRIPTION
Currently if you register an event handler:

```
links.events.addListener(mytimeline, 'add', modifyEventText);
```

Changes to the event inside the modifyEventText method are not displayed because in timeline.js  the item is retrieved (on line 2938) before calling the handler (on line 2952) and is not updated after the handler and before calling updateData.

This simple PR fixes that :)
