### PR TITLE
fixing unuseful setOptions()

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -294,7 +294,6 @@ links.Timeline.prototype.draw = function(data, options) {
         console.log("WARNING: Passing options in draw() is deprecated. Pass options to the constructur or use setOptions() instead!");       
         this.setOptions(options);
     }
-    this.setOptions(options);
 
     if (this.options.selectable) {
         links.Timeline.addClassName(this.dom.frame, "timeline-selectable");


### PR DESCRIPTION
just realized there is still a call to setOptions() that should be removed (see https://github.com/almende/chap-links-library/pull/321)
