### PR TITLE
[New feature] Add text to both ends of a link

### DIFF
--- a/js/src/network/doc/index.html
+++ b/js/src/network/doc/index.html
@@ -614,6 +614,20 @@ linksTable.addRow({
         <td>no</td>
         <td>Text to be displayed halfway the link.</td>
     </tr>
+    
+    <tr>
+        <td>textFrom</td>
+        <td>string</td>
+        <td>no</td>
+        <td>Text to be displayed on the start of the link.</td>
+    </tr>
+    
+    <tr>
+        <td>textTo</td>
+        <td>string</td>
+        <td>no</td>
+        <td>Text to be displayed on the end of the link.</td>
+    </tr>
 
     <tr>
         <td>timestamp</td>

--- a/js/src/network/network.js
+++ b/js/src/network/network.js
@@ -4008,7 +4008,7 @@ links.Network.Link.prototype._text = function (ctx, text, x, y) {
         ctx.font = ((this.from.selected || this.to.selected) ? "bold " : "") +
             this.fontSize + "px " + this.fontFace;
         ctx.fillStyle = 'white';
-        var width = ctx.measureText(this.text).width;
+        var width = ctx.measureText(text).width;
         var height = this.fontSize;
         var left = x - width / 2;
         var top = y - height / 2;
@@ -4019,7 +4019,7 @@ links.Network.Link.prototype._text = function (ctx, text, x, y) {
         ctx.fillStyle = this.fontColor || "black";
         ctx.textAlign = "left";
         ctx.textBaseline = "top";
-        ctx.fillText(this.text, left, top);
+        ctx.fillText(text, left, top);
     }
 };
 

--- a/js/src/network/network.js
+++ b/js/src/network/network.js
@@ -3985,12 +3985,12 @@ links.Network.Link.prototype._drawText = function (ctx) {
     }
     
     if (this.textFrom) {
-        var point = this._pointOnLine(0.3);
+        var point = this._pointOnLine(0.25);
         this._text(ctx, this.textFrom, point.x, point.y);
     }
     
     if (this.textTo) {
-        var point = this._pointOnLine(0.7);
+        var point = this._pointOnLine(0.75);
         this._text(ctx, this.textTo, point.x, point.y);
     }
 };

--- a/js/src/network/network.js
+++ b/js/src/network/network.js
@@ -3612,7 +3612,9 @@ links.Network.Link.prototype.setProperties = function(properties, constants) {
     if (properties.id != undefined)         {this.id = properties.id;}
     if (properties.style != undefined)      {this.style = properties.style;}
     if (properties.text != undefined)       {this.text = properties.text;}
-    if (this.text) {
+    if (properties.textTo != undefined)       {this.textTo = properties.textTo;}
+    if (properties.textFrom != undefined)       {this.textFrom = properties.textFrom;}
+    if (this.text || this.textTo || this.textFrom) {
         this.fontSize = constants.links.fontSize;
         this.fontFace = constants.links.fontFace;
         this.fontColor = constants.links.fontColor;
@@ -3904,10 +3906,7 @@ links.Network.Link.prototype._drawLine = function(ctx) {
         this._line(ctx);
 
         // draw text
-        if (this.text) {
-            point = this._pointOnLine(0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
     else {
         var radius = this.length / 2 / Math.PI;
@@ -3971,6 +3970,29 @@ links.Network.Link.prototype._circle = function (ctx, x, y, radius) {
     ctx.beginPath();
     ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
     ctx.stroke();
+};
+
+/**
+ * Draw text properties of a link if applicable
+ * @param {CanvasRenderingContext2D} ctx
+ * @author Marc-Antoine Fortier
+ * @date 2015-03-16
+ */
+links.Network.Link.prototype._drawText = function (ctx) {
+    if (this.text) {
+        point = this._pointOnLine(0.5);
+        this._text(ctx, this.text, point.x, point.y);
+    }
+    
+    if (this.textFrom) {
+        var point = this._pointOnLine(0.3);
+        this._text(ctx, this.textFrom, point.x, point.y);
+    }
+    
+    if (this.textTo) {
+        var point = this._pointOnLine(0.7);
+        this._text(ctx, this.textTo, point.x, point.y);
+    }
 };
 
 /**
@@ -4064,10 +4086,7 @@ links.Network.Link.prototype._drawDashLine = function(ctx) {
     ctx.stroke();
 
     // draw text
-    if (this.text) {
-        var point = this._pointOnLine(0.5);
-        this._text(ctx, this.text, point.x, point.y);
-    }
+    this._drawText(ctx);
 };
 
 /**
@@ -4145,10 +4164,7 @@ links.Network.Link.prototype._drawMovingDot = function(ctx) {
         if (this.dot > 1.0) this.dot = 0.0;
 
         // draw text
-        if (this.text) {
-            point = this._pointOnLine(0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
     else {
         // TODO: moving dot for a circular edge
@@ -4186,10 +4202,7 @@ links.Network.Link.prototype._drawArrow = function(ctx) {
         }
 
         // draw text
-        if (this.text) {
-            point = this._pointOnLine(0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
     else {
         // draw circle
@@ -4222,10 +4235,7 @@ links.Network.Link.prototype._drawArrow = function(ctx) {
         }
 
         // draw text
-        if (this.text) {
-            point = this._pointOnCircle(x, y, radius, 0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
 };
 
@@ -4274,10 +4284,7 @@ links.Network.Link.prototype._drawArrowEnd = function(ctx) {
         ctx.stroke();
 
         // draw text
-        if (this.text) {
-            var point = this._pointOnLine(0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
     else {
         // draw circle
@@ -4318,10 +4325,7 @@ links.Network.Link.prototype._drawArrowEnd = function(ctx) {
         ctx.stroke();
 
         // draw text
-        if (this.text) {
-            point = this._pointOnCircle(x, y, radius, 0.5);
-            this._text(ctx, this.text, point.x, point.y);
-        }
+        this._drawText(ctx);
     }
 
 };


### PR DESCRIPTION
A link can have text on his first quarter (25%), on his half (50%) and on his third quarter (75%).

![screenshot](https://cloud.githubusercontent.com/assets/5982196/6684375/dff2eeaa-cc90-11e4-81d4-36607969413f.png)