### PR TITLE
Add an ability to bind actions for clusters

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -5885,7 +5885,7 @@ links.Timeline.ClusterGenerator.prototype.getClusters = function (scale, maxItem
                         var cluster;
                         var title = 'Cluster containing ' + count +
                             ' events. Zoom in to see the individual events.';
-                        var content = '<div title="' + title + '" data-cluster-id="' + clusters.length + '" class="timeline-cluster">' + count + '</div>';
+                        var content = '<div title="' + title + '" data-cluster-id="' + clusters.length + '" class="timeline-cluster">' + count + 'events </div>';
                         var group = item.group ? item.group.content : undefined;
                         if (containsRanges) {
                             // boxes and/or ranges

--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -5885,7 +5885,7 @@ links.Timeline.ClusterGenerator.prototype.getClusters = function (scale, maxItem
                         var cluster;
                         var title = 'Cluster containing ' + count +
                             ' events. Zoom in to see the individual events.';
-                        var content = '<div title="' + title + '">' + count + ' events</div>';
+                        var content = '<div title="' + title + '" data-cluster-id="' + clusters.length + '" class="timeline-cluster">' + count + '</div>';
                         var group = item.group ? item.group.content : undefined;
                         if (containsRanges) {
                             // boxes and/or ranges

--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -5885,7 +5885,7 @@ links.Timeline.ClusterGenerator.prototype.getClusters = function (scale, maxItem
                         var cluster;
                         var title = 'Cluster containing ' + count +
                             ' events. Zoom in to see the individual events.';
-                        var content = '<div title="' + title + '" data-cluster-index="' + clusters.length + '" class="timeline-cluster">' + count + 'events</div>';
+                        var content = '<div title="' + title + '" data-cluster-index="' + clusters.length + '" class="timeline-cluster">' + count + ' events</div>';
                         var group = item.group ? item.group.content : undefined;
                         if (containsRanges) {
                             // boxes and/or ranges

--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -5885,7 +5885,7 @@ links.Timeline.ClusterGenerator.prototype.getClusters = function (scale, maxItem
                         var cluster;
                         var title = 'Cluster containing ' + count +
                             ' events. Zoom in to see the individual events.';
-                        var content = '<div title="' + title + '" data-cluster-id="' + clusters.length + '" class="timeline-cluster">' + count + 'events </div>';
+                        var content = '<div title="' + title + '" data-cluster-index="' + clusters.length + '" class="timeline-cluster">' + count + 'events</div>';
                         var group = item.group ? item.group.content : undefined;
                         if (containsRanges) {
                             // boxes and/or ranges


### PR DESCRIPTION
I think it's good feature to be able to bind some actions for clusters, e.g. `click`.

1. When you have a lot of items in timeline, there's a use case when clusters never expanded.
2. When you want to zoom in on cluster click.
```js
$('.timeline-cluster').once().click(function() {
      var cluster = timeline.getCluster($(this).data('cluster-index'));
      // Do whatever you want with cluster and his timeline items.
      // - you can open dialog with list of items inside clusters.
      // - you can zoom in timeline:
      // links.Timeline.preventDefault(event);
      // links.Timeline.stopPropagation(event);
      // timeline.zoom(0.4);
      // timeline.trigger("rangechange");
      // timeline.trigger("rangechanged");
    });
```