### PR TITLE
fix for #353

### DIFF
--- a/js/src/timeline/timeline.js
+++ b/js/src/timeline/timeline.js
@@ -5328,9 +5328,9 @@ links.Timeline.prototype.stackCalculateFinal = function(items) {
 
         if (!groupedItems[group.content]) {
             if (axisOnTop) {
-                groupBase += options.groupMinHeight + eventMargin;
+                groupBase += Math.max(options.groupMinHeight, group.labelHeight) + eventMargin;
             } else {
-                groupBase -= (options.groupMinHeight + eventMargin);
+                groupBase -= (Math.max(options.groupMinHeight, group.labelHeight) + eventMargin);
             }
             continue;
         }


### PR DESCRIPTION
possible fix for (Timeline - Wrong item top position with empty group #353)